### PR TITLE
Removed outdated line about project split from color-describer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,6 @@ Colors in Context
 
 Code and supplementary material
 
-Note that this repo is split off from a larger project still in development:
-https://github.com/futurulus/coop-nets
-
 Dependencies
 ------------
 


### PR DESCRIPTION
As mentioned in the email, the line was originally from https://github.com/stanfordnlp/color-describer which became part of the "base speaker." As this line is no longer accurate, I've deleted it.